### PR TITLE
Option to clear data after read()

### DIFF
--- a/src/components/session/session.php
+++ b/src/components/session/session.php
@@ -59,11 +59,20 @@ class Session {
 	 * Read Session information for the given index
 	 *
 	 * @param string $name The name of the index to read
+	 * @param boolean $persist If set data will persist, otherwise will be cleared after read
 	 * @return mixed The value stored in $name of the session, or an empty string.
 	 */
-	public function read($name) {
-		if (isset($_SESSION[$name]))
-			return $_SESSION[$name];
+	public function read($name, $persist=true) {
+		if (isset($_SESSION[$name])){
+			$val = $_SESSION[$name];
+
+			if($persist == false){
+				$this->clear($name);
+			}
+
+			return $val;
+		}
+
 		return "";
 	}
 


### PR DESCRIPTION
Default behavior is still to persist data, but now option exists in Session::read() to purge data after retrieval.

Use case: using Session class for temporary storage only (i.e.: some ID or something that needs to be carried over after a redirect but not used after).

``` php
$this->Session->read("some name"); // Default behavior, "some name" value persists after call

$this->Session->read("some name", false); // "some name" will be cleared after call
```
